### PR TITLE
Use pointer instead of mouse to support touch input

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,7 +118,7 @@ const TEXT_TO_CENTER_SNAP_THRESHOLD = 30;
 let lastCanvasWidth = -1;
 let lastCanvasHeight = -1;
 
-let lastMouseUp: ((e: any) => void) | null = null;
+let lastPointerUp: ((e: any) => void) | null = null;
 
 export function viewportCoordsToSceneCoords(
   { clientX, clientY }: { clientX: number; clientY: number },
@@ -222,7 +222,7 @@ export class App extends React.Component<{}, AppState> {
     document.addEventListener("cut", this.onCut);
 
     document.addEventListener("keydown", this.onKeyDown, false);
-    document.addEventListener("mousemove", this.getCurrentCursorPosition);
+    document.addEventListener("pointermove", this.getCurrentCursorPosition);
     window.addEventListener("resize", this.onResize, false);
     window.addEventListener("unload", this.onUnload, false);
 
@@ -254,7 +254,7 @@ export class App extends React.Component<{}, AppState> {
 
     document.removeEventListener("keydown", this.onKeyDown, false);
     document.removeEventListener(
-      "mousemove",
+      "pointermove",
       this.getCurrentCursorPosition,
       false
     );
@@ -268,7 +268,7 @@ export class App extends React.Component<{}, AppState> {
     this.forceUpdate();
   };
 
-  private getCurrentCursorPosition = (e: MouseEvent) => {
+  private getCurrentCursorPosition = (e: PointerEvent) => {
     this.setState({ cursorX: e.x, cursorY: e.y });
   };
 
@@ -667,18 +667,18 @@ export class App extends React.Component<{}, AppState> {
               left: e.clientX
             });
           }}
-          onMouseDown={e => {
-            if (lastMouseUp !== null) {
-              // Unfortunately, sometimes we don't get a mouseup after a mousedown,
+          onPointerDown={e => {
+            if (lastPointerUp !== null) {
+              // Unfortunately, sometimes we don't get a poinerup after a pointerup,
               // this can happen when a contextual menu or alert is triggered. In order to avoid
-              // being in a weird state, we clean up on the next mousedown
-              lastMouseUp(e);
+              // being in a weird state, we clean up on the next pointerup
+              lastPointerUp(e);
             }
 
             // pan canvas on wheel button drag
             if (e.button === 1) {
               let { clientX: lastX, clientY: lastY } = e;
-              const onMouseMove = (e: MouseEvent) => {
+              const onPointerMove = (e: PointerEvent) => {
                 document.documentElement.style.cursor = `grabbing`;
                 let deltaX = lastX - e.clientX;
                 let deltaY = lastY - e.clientY;
@@ -689,22 +689,22 @@ export class App extends React.Component<{}, AppState> {
                   scrollY: state.scrollY - deltaY
                 }));
               };
-              const onMouseUp = (lastMouseUp = (e: MouseEvent) => {
-                lastMouseUp = null;
+              const onPointerUp = (lastPointerUp = (e: PointerEvent) => {
+                lastPointerUp = null;
                 resetCursor();
-                window.removeEventListener("mousemove", onMouseMove);
-                window.removeEventListener("mouseup", onMouseUp);
+                window.removeEventListener("pointermove", onPointerMove);
+                window.removeEventListener("pointerup", onPointerUp);
               });
-              window.addEventListener("mousemove", onMouseMove, {
+              window.addEventListener("pointermove", onPointerMove, {
                 passive: true
               });
-              window.addEventListener("mouseup", onMouseUp);
+              window.addEventListener("pointerup", onPointerUp);
               return;
             }
 
-            // only handle left mouse button
+            // only handle left pointer button
             if (e.button !== 0) return;
-            // fixes mousemove causing selection of UI texts #32
+            // fixes pointermove causing selection of UI texts #32
             e.preventDefault();
             // Preventing the event above disables default behavior
             //  of defocusing potentially focused input, which is what we want
@@ -781,7 +781,7 @@ export class App extends React.Component<{}, AppState> {
                     elementIsAddedToSelection = true;
                   }
 
-                  // We duplicate the selected element if alt is pressed on Mouse down
+                  // We duplicate the selected element if alt is pressed on Pointer down
                   if (e.altKey) {
                     elements = [
                       ...elements.map(element => ({
@@ -861,7 +861,7 @@ export class App extends React.Component<{}, AppState> {
               lastY = e.clientY - CANVAS_WINDOW_OFFSET_TOP;
             }
 
-            const onMouseMove = (e: MouseEvent) => {
+            const onPointerMove = (e: PointerEvent) => {
               const target = e.target;
               if (!(target instanceof HTMLElement)) {
                 return;
@@ -970,7 +970,7 @@ export class App extends React.Component<{}, AppState> {
 
               if (hitElement?.isSelected) {
                 // Marking that click was used for dragging to check
-                // if elements should be deselected on mouseup
+                // if elements should be deselected on pointerup
                 draggingOccured = true;
                 const selectedElements = elements.filter(el => el.isSelected);
                 if (selectedElements.length) {
@@ -1029,23 +1029,23 @@ export class App extends React.Component<{}, AppState> {
               this.forceUpdate();
             };
 
-            const onMouseUp = (e: MouseEvent) => {
+            const onPointerUp = (e: PointerEvent) => {
               const {
                 draggingElement,
                 resizingElement,
                 elementType
               } = this.state;
 
-              lastMouseUp = null;
-              window.removeEventListener("mousemove", onMouseMove);
-              window.removeEventListener("mouseup", onMouseUp);
+              lastPointerUp = null;
+              window.removeEventListener("pointermove", onPointerMove);
+              window.removeEventListener("pointerup", onPointerUp);
 
               if (
                 elementType !== "selection" &&
                 draggingElement &&
                 isInvisiblySmallElement(draggingElement)
               ) {
-                // remove invisible element which was added in onMouseDown
+                // remove invisible element which was added in onPointerDown
                 elements = elements.slice(0, -1);
                 this.setState({
                   draggingElement: null
@@ -1066,7 +1066,7 @@ export class App extends React.Component<{}, AppState> {
               // from hitted element
               //
               // If click occured and elements were dragged or some element
-              // was added to selection (on mousedown phase) we need to keep
+              // was added to selection (on pointerdown phase) we need to keep
               // selection unchanged
               if (
                 hitElement &&
@@ -1103,12 +1103,12 @@ export class App extends React.Component<{}, AppState> {
               this.forceUpdate();
             };
 
-            lastMouseUp = onMouseUp;
+            lastPointerUp = onPointerUp;
 
-            window.addEventListener("mousemove", onMouseMove);
-            window.addEventListener("mouseup", onMouseUp);
+            window.addEventListener("pointermove", onPointerMove);
+            window.addEventListener("pointerup", onPointerUp);
 
-            // We don't want to save history on mouseDown, only on mouseUp when it's fully configured
+            // We don't want to save history on pointerdown, only on pointerup when it's fully configured
             history.skipRecording();
             this.forceUpdate();
           }}
@@ -1191,7 +1191,7 @@ export class App extends React.Component<{}, AppState> {
               }
             });
           }}
-          onMouseMove={e => {
+          onPointerMove={e => {
             const hasDeselectedButton = Boolean(e.buttons);
             if (hasDeselectedButton || this.state.elementType !== "selection") {
               return;


### PR DESCRIPTION
I wondered if it would be easy to make this work with the touch screen of my laptop and it just seems to work with replacing mouse with pointer events.

I didn't test this thoroughly to verify that mouse isn't broken or other touch input devices work as well (e.g. a phone).